### PR TITLE
Use wildcard function in Makefile to find source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MLCOMP ?= mlton -mlb-path-map $(HOME)/.mlton/mlb-path-map
-FILES=apl2tail.mlb Apl2Tail.sml $(shell ls -1 tail/*.{sig,sml,mlb})
+FILES=apl2tail.mlb Apl2Tail.sml $(wildcard tail/*.{sig,sml,mlb})
 
 .PHONY: all
 all: aplt


### PR DESCRIPTION
Fixes the following warning I was getting when installing from smackage.

```
ls: cannot access tail/*.{sig,sml,mlb}: No such file or directory
```
