### PR TITLE
Improve commandline interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 MLCOMP ?= mlton -mlb-path-map $(HOME)/.mlton/mlb-path-map
 FILES=src/flags.sml src/flags.mlb src/aplt.sml src/aplt.mlb \
   src/apl2tail.mlb src/Apl2Tail.sml src/Tail2Laila.sml \
+  src/util.sig src/util.sml src/util.mlb \
   $(shell ls -1 src/tail/*.sig src/tail/*.sml src/tail/*.mlb) \
   $(shell ls -1 src/il/*.sig src/il/*.sml src/il/*.mlb) \
   $(shell ls -1 src/laila/*.sig src/laila/*.sml src/laila/*.mlb)

--- a/src/Apl2Tail.sml
+++ b/src/Apl2Tail.sml
@@ -1086,7 +1086,7 @@ fun compileExp (flags : Flags.flags) G (e : AplAst.exp) : res =
                 SOME ofile => T.outprog p_types ofile p
               | NONE =>
                 if p_tail andalso not verbose_p then
-                  (print "TAIL program:\n";
+                  (if not silent_p then print "TAIL program:\n" else ();
                    print (T.pp_prog p_types p);
                    print "\n")
                 else ()  (* program already printed! *)

--- a/src/aplt.sml
+++ b/src/aplt.sml
@@ -43,7 +43,7 @@ fun compileAndRun (flags,files) =
                             else ()  (* program already printed! *)
                      end
              end
-           | NONE => ()
+           | NONE => OS.Process.exit OS.Process.failure
     end
         
 val name = CommandLine.name()

--- a/src/flags.sml
+++ b/src/flags.sml
@@ -13,7 +13,7 @@ fun flag flags s =
 
 fun isFlag s =
     case String.explode s of
-        #"-" :: _ => true
+        #"-" :: _ :: _ => true
       | _ => false
 
 fun runargs {unaries: string list,

--- a/src/flags.sml
+++ b/src/flags.sml
@@ -29,7 +29,7 @@ fun runargs {unaries: string list,
               | f :: rest => 
                 if isFlag f then loop rest ((f,NONE)::acc)
                 else run(rev acc, args)
-              | nil => print(usage () ^ "\n")
+              | nil => (print(usage () ^ "\n"); OS.Process.exit OS.Process.failure)
     in loop (CommandLine.arguments()) nil
     end
 

--- a/src/util.sml
+++ b/src/util.sml
@@ -53,9 +53,12 @@ val maxInt = case Int.maxInt of
                  SOME i => i
                | NONE => raise Fail "Util.no maxInt"
 
+
 (* File manipulation *)
 fun readFile f =
-    let val is = TextIO.openIn f
+    let val is = case f of
+                    "-" => TextIO.stdIn
+                  | _   => TextIO.openIn f
     in let val s = TextIO.inputAll is
        in TextIO.closeIn is;
           s


### PR DESCRIPTION
`aplt` should also accept programs on stdin: `cat foo.apl | aplt -`. If the program encounters an error it should exit with an error code.